### PR TITLE
Prohibit sundown-added LFs from source maps

### DIFF
--- a/src/ByteBuffer.cc
+++ b/src/ByteBuffer.cc
@@ -30,10 +30,16 @@ static size_t strnlen_utf8(const char* s, size_t len)
 /* Convert range of bytes to a range of characters */
 static CharactersRange BytesRangeToCharactersRange(const BytesRange& bytesRange, const ByteBuffer& byteBuffer)
 {
-    if (byteBuffer.empty() ||
-        bytesRange.location + bytesRange.length > byteBuffer.length())
+    if (byteBuffer.empty()) {
         return CharactersRange();
+    }
     
+    BytesRange workRange = bytesRange;
+    if (bytesRange.location + bytesRange.length > byteBuffer.length()) {
+        // Accomodate maximum possible length
+        workRange.length -= bytesRange.location + bytesRange.length - byteBuffer.length();
+    }
+
     size_t charLocation = 0;
     if (bytesRange.location > 0)
         charLocation = strnlen_utf8(byteBuffer.c_str(), bytesRange.location);

--- a/src/MarkdownNode.cc
+++ b/src/MarkdownNode.cc
@@ -127,7 +127,17 @@ void MarkdownNode::printNode(size_t level) const
     }
     
     cout << " (type " << type << ", data " << data << ") - ";
-    cout << "`" << text << "` ";
+    cout << "`" << text << "`";
+    
+    if (!sourceMap.empty()) {
+        for (mdp::BytesRangeSet::const_iterator it = sourceMap.begin();
+             it != sourceMap.end();
+             ++it) {
+            std::cout << ((it == sourceMap.begin()) ? " :" : ";");
+            std::cout << it->location << ":" << it->length;
+        }
+    }
+    
     cout << std::endl;
     
     for (MarkdownNodeIterator it = m_children->begin();

--- a/src/MarkdownParser.h
+++ b/src/MarkdownParser.h
@@ -36,6 +36,7 @@ namespace mdp {
         MarkdownNode* m_workingNode;
         bool m_listBlockContext;
         const ByteBuffer* m_source;
+        size_t m_sourceLength;
         
         static const size_t OutputUnitSize;
         static const size_t MaxNesting;

--- a/test/test-MarkdownParser.cc
+++ b/test/test-MarkdownParser.cc
@@ -547,3 +547,29 @@ TEST_CASE("Source map crash", "[parser][sourcemap][issue][snowcrash][62]")
     REQUIRE(ast.data == 0);
     REQUIRE(ast.children().size() == 2);
 }
+
+TEST_CASE("Map node without trailing newline", "[parser][sourcemap]")
+{
+    MarkdownParser parser;
+    MarkdownNode ast;
+    
+    ByteBuffer src = "# Hello World";
+    
+    parser.parse(src, ast);
+    
+    REQUIRE(ast.type == RootMarkdownNodeType);
+    REQUIRE(ast.text.empty());
+    REQUIRE(ast.data == 0);
+    REQUIRE(ast.children().size() == 1);
+    REQUIRE(ast.sourceMap.size() == 1);
+    REQUIRE(ast.sourceMap[0].location == 0);
+    REQUIRE(ast.sourceMap[0].length == 13);
+    
+    MarkdownNode& node = ast.children().front();
+    REQUIRE(node.type == HeaderMarkdownNodeType);
+    REQUIRE(node.text == "Hello World");
+    REQUIRE(node.children().empty());
+    REQUIRE(node.sourceMap.size() == 1);
+    REQUIRE(node.sourceMap[0].location == 0);
+    REQUIRE(node.sourceMap[0].length == 13);
+}


### PR DESCRIPTION
This commit addresses the "+1 LF" issue Sundown is responsible for – If an input markdown buffer does not contain a trailing LF sundown adds an artificial LF in order for parsing to work. This however affects the sundown source maps as well. This is a Sundown design flaw and should be eventually addressed there. Until then we will reduce to add or truncate any source map that exceeds actual buffer size. 
