### PR TITLE
Increase the limit for max nesting to 32

### DIFF
--- a/src/MarkdownParser.cc
+++ b/src/MarkdownParser.cc
@@ -13,7 +13,7 @@
 using namespace mdp;
 
 const size_t MarkdownParser::OutputUnitSize = 64;
-const size_t MarkdownParser::MaxNesting = 16;
+const size_t MarkdownParser::MaxNesting = 32;
 const int MarkdownParser::ParserExtensions = MKDEXT_FENCED_CODE | MKDEXT_NO_INTRA_EMPHASIS | MKDEXT_LAX_SPACING /*| MKDEXT_TABLES */;
 
 #define NO_WORKING_NODE_ERR std::logic_error("no working node")

--- a/test/test-MarkdownParser.cc
+++ b/test/test-MarkdownParser.cc
@@ -574,6 +574,62 @@ TEST_CASE("Map node without trailing newline", "[parser][sourcemap]")
     REQUIRE(node.sourceMap[0].length == 13);
 }
 
+TEST_CASE("Parse six nested level list items", "[parser]")
+{
+    MarkdownParser parser;
+    MarkdownNode ast;
+
+    ByteBuffer src = \
+    "+ 1\n"\
+    "    + 2\n"\
+    "        + 3\n"\
+    "            + 4\n"\
+    "                + 5\n"\
+    "                    + 6\n";
+
+    parser.parse(src, ast);
+
+    REQUIRE(ast.type == RootMarkdownNodeType);
+    REQUIRE(ast.text.empty());
+    REQUIRE(ast.children().size() == 1);
+
+    MarkdownNode& list = ast.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 2);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "1\n");
+
+    list = list.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 2);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "2\n");
+
+    list = list.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 2);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "3\n");
+
+    list = list.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 2);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "4\n");
+
+    list = list.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 2);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "5\n");
+
+    list = list.children().back();
+    REQUIRE(list.type == ListItemMarkdownNodeType);
+    REQUIRE(list.children().size() == 1);
+    REQUIRE(list.children().front().type == ParagraphMarkdownNodeType);
+    REQUIRE(list.children().front().text == "6\n");
+}
+
 TEST_CASE("Multi-paragraph list item source map", "[parser][sourcemap]")
 {
     MarkdownParser parser;


### PR DESCRIPTION
This PR increases the max nesting value of markdown from 16 to 32. With this, 6th nested level list item gets parsed properly. But the problem is not yet completely fixed. We just moved the value to 11th nested level list item (which I think is a safe limit and will not be reached soon.)

We can completely remove the nesting constraint as shown in https://github.com/apiaryio/sundown/commit/0f2b98e83ea7cb9b68c01e516325ee955187dcea