### PR TITLE
Increase the limit for max nesting to 128

### DIFF
--- a/src/MarkdownParser.cc
+++ b/src/MarkdownParser.cc
@@ -13,7 +13,7 @@
 using namespace mdp;
 
 const size_t MarkdownParser::OutputUnitSize = 64;
-const size_t MarkdownParser::MaxNesting = 32;
+const size_t MarkdownParser::MaxNesting = 128;
 const int MarkdownParser::ParserExtensions = MKDEXT_FENCED_CODE | MKDEXT_NO_INTRA_EMPHASIS | MKDEXT_LAX_SPACING /*| MKDEXT_TABLES */;
 
 #define NO_WORKING_NODE_ERR std::logic_error("no working node")


### PR DESCRIPTION
This pull request increases the maximum amount of nesting from 32 to 128 (by 4 times) due to users using 11th onwards nested list items inside MSON.

I can't see any real reason not to set this to 128 so I've just done that.

This was increased due to https://github.com/apiaryio/drafter/issues/252. See https://github.com/apiaryio/markdown-parser/pull/13 for previous attempts to increase the maximum nesting along with the sundown tracking issue https://github.com/apiaryio/sundown/issues/11.